### PR TITLE
Fix interface list on install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ cp -i $DIRECTORY/Install/$CONFFOLDER/bird4.conf /opt/etc/bird4.conf
 
 # Reading vpn and provider interfaces, replacing in scripts and bird configuration
 echo -e "\n----------------------"
-ifconfig | grep -B 1 "inet addr" | awk '{print $1$2}' | sed ':a;N;$!ba;s/Link\n/ <--/g;s/inetaddr:/ /g;s/--\n//g'
+ifconfig | grep -B 1 "inet" | awk '{print $1$2}' | sed ':a;N;$!ba;s/Link\n/ <--/g;s/inetaddr:/ /g;s/--\n//g'
 
 echo "Enter the name of the provider interface from the list above (for exaple ppp0 or eth3)"
 read ISP


### PR DESCRIPTION
В текущей реализации `install.sh` возвращает пустой список интерфейсов. 

Результат выполенения `ifconfig` больше не содержит строчку `inet addr`.

Например:

```
nwg5: flags=209<UP,POINTOPOINT,RUNNING,NOARP>  mtu 1324
        inet 10.77.77.3  netmask 255.255.255.255  destination 10.77.77.3
        unspec 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00  txqueuelen 50  (UNSPEC)
        RX packets 1308  bytes 463540 (452.6 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 1772  bytes 240156 (234.5 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```
