### PR TITLE
Исправлена опечатка в скрипте удаления uninstall.sh при удалении IPse…

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -61,7 +61,7 @@ if [ -d "$HOME_FOLDER/IPset4Static" ]; then
   echo -e "\nFound iPset4Static\nDo you want uninstall it? y/n"
   read ANS
   if [ "$ANS" == "y" ]; then
-    sh $HOME_FOLDER/IPset4Static/uninstal.sh
+    sh $HOME_FOLDER/IPset4Static/uninstall.sh
   fi
 fi
 


### PR DESCRIPTION
Исправлена опечатка в скрипте удаления uninstall.sh при удалении IPset4Static
Ранее при удалении, после положительного ответа на вопрос "Удалить IPset4Static" он не удалялся, так как была опечатка в скрипте удаления